### PR TITLE
Potential fix for code scanning alert no. 19: Disabling certificate validation

### DIFF
--- a/scripts/generate-minimal-json.mjs
+++ b/scripts/generate-minimal-json.mjs
@@ -11,8 +11,7 @@
  * Run with: node scripts/generate-minimal-json.mjs
  */
 
-// Disable TLS certificate validation for Digital Ocean managed PostgreSQL
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+// (Certificate validation is now enforced for TLS connections)
 
 import pg from 'pg';
 import fs from 'fs';
@@ -51,8 +50,8 @@ if (!DATABASE_URL) {
 // SSL configuration for Digital Ocean managed PostgreSQL
 // Always use SSL with rejectUnauthorized: false to avoid certificate issues
 const sslConfig = {
-  rejectUnauthorized: false,
-  checkServerIdentity: () => undefined,
+  rejectUnauthorized: true, // Enforce certificate validation
+  // If needed, add `ca: fs.readFileSync('path/to/ca-cert.pem').toString()` here
 };
 
 const pool = new Pool({


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/19](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/19)

The ideal fix is to remove the global setting of `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';` and to enable certificate validation. SSL options for the PostgreSQL connection should be set to only trust valid certificates. This typically involves setting `rejectUnauthorized: true` and, if required, providing the server's CA certificate so the client can correctly verify the server’s identity. In the context of connecting to DigitalOcean managed PostgreSQL, DigitalOcean supplies its public CA certificate and recommends clients use this CA instead of disabling validation.

**Changes to make:**
- Remove or comment out line 15: `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';`.
- Change the `sslConfig` object to set `rejectUnauthorized: true`.
- If available/suitable, provide a CA certificate (in PEM format), e.g., via environment variable, configuration, or from a known file location. If you cannot add code to read a CA from file, at least enable validation with the correct option.
- Remove or update `checkServerIdentity` so it does not skip verification.

**What is needed:**
- Edits on lines involving the global TLS env variable.
- Edits to the SSL configuration used in the PostgreSQL pool.
- Potential additions to load a CA certificate if you have code to do so (cannot add such code unless shown—but the fix can be structured to support it if needed in the environment).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
