### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL scheme check

### DIFF
--- a/src/lib/realtime-validation.ts
+++ b/src/lib/realtime-validation.ts
@@ -77,8 +77,12 @@ export const validateUrl = (url: string, fieldName: string = 'URL'): ValidationR
   try {
     const urlObj = new URL(url);
     
-    // Reject javascript: and data: protocols
-    if (urlObj.protocol === 'javascript:' || urlObj.protocol === 'data:') {
+    // Reject javascript:, data:, and vbscript: protocols
+    if (
+      urlObj.protocol === 'javascript:' ||
+      urlObj.protocol === 'data:' ||
+      urlObj.protocol === 'vbscript:'
+    ) {
       return {
         isValid: false,
         error: 'Invalid protocol in URL',


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/11](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/11)

To address this issue, update the protocol validation logic in `validateUrl` to also reject URLs whose protocol is `vbscript:`. This can be done by adding another condition to the existing check on line 81 (currently `urlObj.protocol === 'javascript:' || urlObj.protocol === 'data:'`). Update it to include `urlObj.protocol === 'vbscript:'`. No additional imports or extensive changes are necessary. Be careful to avoid changing any other logic or altering functionality outside this very specific protocol check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
