### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/src/components/WishlistForms.tsx
+++ b/src/components/WishlistForms.tsx
@@ -584,7 +584,15 @@ const WishlistForm = ({ services = [], practitioners = [], user: initialUser = n
         result = validateEmail(value);
         break;
       case 'url':
-        if (value.includes('github.com')) {
+        let isGitHubUrl = false;
+        try {
+          const parsedUrl = new URL(value);
+          // Only accept plain github.com (not attacker-controlled or subdomain unless desired)
+          isGitHubUrl = parsedUrl.hostname === 'github.com';
+        } catch (e) {
+          isGitHubUrl = false;
+        }
+        if (isGitHubUrl) {
           result = validateGitHubUrl(value);
         } else {
           result = validateUrl(value, fieldName);


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/10](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/10)

To reliably detect whether a URL is referencing `github.com` (or one of its specific subdomains, if desired), we should parse the URL and inspect its `hostname` component, rather than searching for a substring within the entire string. We can safely use the standard `URL` class provided by modern JavaScript/TypeScript environments for this purpose. The fix is:

- In the real-time validation handler, replace the substring check for `'github.com'` with logic that tries to parse the URL and compares its `hostname` to `'github.com'` (optionally, including subdomains if required).
- If the URL cannot be parsed, treat it as not being a GitHub URL.
- To avoid exceptions, wrap the parsing in a try/catch.
- No new imports are necessary, as the global `URL` class is standard.

Only the block in the `validateField` function starting at line 579 (specifically the `'url'` case) needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
