### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/realtime-validation.ts
+++ b/src/lib/realtime-validation.ts
@@ -122,10 +122,26 @@ export const validateGitHubUrl = (url: string): ValidationResult => {
     return urlValidation;
   }
   
-  if (!url.includes('github.com')) {
+  try {
+    const urlObj = new URL(url);
+    // Explicit whitelist of allowed GitHub hosts:
+    const allowedHosts = [
+      'github.com',
+      'www.github.com',
+      'gist.github.com',
+      'api.github.com'
+    ];
+    if (!allowedHosts.includes(urlObj.hostname)) {
+      return {
+        isValid: false,
+        error: 'Please enter a GitHub URL',
+        severity: 'error'
+      };
+    }
+  } catch {
     return {
       isValid: false,
-      error: 'Please enter a GitHub URL',
+      error: 'Invalid GitHub URL format',
       severity: 'error'
     };
   }


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/9](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/9)

To fix the issue, we should parse the provided URL and ensure the `host` component matches the intended values for GitHub, e.g., exactly `github.com` or possibly subdomains such as `gist.github.com` or `api.github.com`. This check should replace the substring check entirely. Use the JavaScript `URL` class, already employed in `validateUrl`, to obtain the hostname. Only allow known, legitimate GitHub hostnames. Edit only the `validateGitHubUrl` function in `src/lib/realtime-validation.ts` (lines 115–134): remove the current substring check and instead parse the URL and check its host or hostname against a whitelist (e.g., `github.com`, `gist.github.com`, `api.github.com`). No new packages or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
