### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/pages/api/check-existing-wishlists.ts
+++ b/src/pages/api/check-existing-wishlists.ts
@@ -72,15 +72,21 @@ export const POST: APIRoute = async ({ request }) => {
       const urlMatches = body.matchAll(/https?:\/\/[^\s\)]+/g);
       for (const match of urlMatches) {
         const repoUrl = match[0];
-        // Only process GitHub URLs (or other common git hosting)
-        if (repoUrl.includes('github.com') || repoUrl.includes('gitlab.com') || repoUrl.includes('bitbucket.org')) {
-          const normalizedUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '');
-          existingWishlists[normalizedUrl] = {
-            issueUrl: issue.html_url,
-            issueNumber: issue.number,
-            isApproved: isApproved,
-            projectTitle: issue.title,
-          };
+        // Only process URLs with allowed hosts (GitHub, GitLab, Bitbucket)
+        try {
+          const parsedUrl = new URL(repoUrl);
+          const allowedHosts = ['github.com', 'gitlab.com', 'bitbucket.org'];
+          if (allowedHosts.includes(parsedUrl.hostname)) {
+            const normalizedUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '');
+            existingWishlists[normalizedUrl] = {
+              issueUrl: issue.html_url,
+              issueNumber: issue.number,
+              isApproved: isApproved,
+              projectTitle: issue.title,
+            };
+          }
+        } catch (e) {
+          // Ignore invalid URLs
         }
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/3](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/3)

**General solution:**  
Instead of checking with `repoUrl.includes('github.com')` etc., we should parse the URL and check if the actual `host` property matches one of a safe list of allowed hostnames (including possible subdomains, if desired). This prevents bypasses using manipulative URLs.

**Specific implementation steps:**  
- For each `repoUrl` match, before processing, use the standard `URL` constructor to parse the URL and extract the hostname (i.e., `new URL(repoUrl).hostname`).
- Check the extracted hostname against a whitelist of domains — e.g., `"github.com"`, `"gitlab.com"`, `"bitbucket.org"`. If subdomains are acceptable, handle those accordingly (using `endsWith` or exact match).
- Only process the URL if its parsed hostname is allowed.

**Required changes:**  
- Update lines in the `for (const match of urlMatches)` loop (lines 73–85) to:
    - Parse `repoUrl` using `new URL(repoUrl)`.
    - Check if the parsed hostname equals (or ends with, if subdomains are accepted) any allowed host.
- Add a `try/catch` block to handle invalid URLs.
- No additional imports are needed if using the built-in `URL` class.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
