### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/src/pages/api/cache-wishlist.ts
+++ b/src/pages/api/cache-wishlist.ts
@@ -327,8 +327,7 @@ export const POST: APIRoute = async ({ request }) => {
   } catch (error) {
     console.error('Error in cache-wishlist:', error);
     return new Response(JSON.stringify({ 
-      error: 'Failed to cache wishlist',
-      details: error instanceof Error ? error.message : String(error)
+      error: 'Failed to cache wishlist'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/7](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/7)

To fix the problem, modify the error response in the POST handler so that it does not include potentially sensitive error details (like `error.message` or stringified `error`). Instead, only return a generic error message such as `'Failed to cache wishlist'`. Logging the error on the server-side (with `console.error`) should remain, so developers can access diagnostic information. The only change needed is to remove the `details` property from the JSON response in the error case, and keep just the generic message.

Specifically:

- In `src/pages/api/cache-wishlist.ts`, lines 329-331 (within the `catch` block for POST), only return `{ error: 'Failed to cache wishlist' }`.
- No additional imports or methods are needed; retain server-side logging for debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
