### PR TITLE
Potential fix for code scanning alert no. 15: Information exposure through a stack trace

### DIFF
--- a/src/pages/api/webhook/cache-refresh.ts
+++ b/src/pages/api/webhook/cache-refresh.ts
@@ -47,8 +47,7 @@ export const POST: APIRoute = async ({ request }) => {
   } catch (error) {
     console.error('❌ Error in cache refresh webhook:', error);
     return new Response(JSON.stringify({ 
-      error: 'Internal server error',
-      details: error instanceof Error ? error.message : String(error)
+      error: 'Internal server error'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/15](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/15)

To fix this problem, the user-facing error response should avoid including internal error details such as the message from the thrown error object. Instead, always return a generic message like "Internal server error" to clients. Internal details (including `error` and its stack trace or message) should be logged on the server for debugging purposes. The recommended edit is to remove the `details` field entirely from the JSON response in the `catch` block (lines 47-56) in `src/pages/api/webhook/cache-refresh.ts`, returning only a generic error field. No imports or method definitions are needed to implement this fix; only the shape of the returned JSON needs changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
