### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through a stack trace

### DIFF
--- a/src/pages/api/public/wishlists.json.ts
+++ b/src/pages/api/public/wishlists.json.ts
@@ -60,8 +60,7 @@ export const GET: APIRoute = async ({ request }) => {
     }
     
     return new Response(JSON.stringify({
-      error: 'Failed to load wishlist data',
-      details: error instanceof Error ? error.message : String(error)
+      error: 'Failed to load wishlist data'
     }), {
       status: 500,
       headers: {


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/6](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/6)

To fix this issue, we should prevent potentially sensitive error information (error message, stringified error) from being exposed to the end user via the API response. Instead, we should return a generic error message such as "An internal server error occurred" or "Failed to load wishlist data" without including error details. Logging of the full error (message and stack) can remain on the server.  

In `src/pages/api/public/wishlists.json.ts`, specifically in the catch block starting at line 25, update the response in line 62-65 so that only a generic error message is provided. The `details` property should be removed, or replaced with a generic "internal error" indicator if required. Internal error details should only be output to the server console via `console.error`. 

No additional dependencies or imports are needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
