### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/src/pages/api/debug-env.ts
+++ b/src/pages/api/debug-env.ts
@@ -30,7 +30,9 @@ export const GET: APIRoute = async () => {
     },
   });
   } catch (error) {
-    return new Response(JSON.stringify({ error: String(error) }), {
+    // Log the actual error details for server-side debugging
+    console.error('Error in /api/debug-env:', error);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }
     });


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/5](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/5)

To fix this issue, error details should not be sent directly to the client. Instead, return a generic error message in the HTTP response (e.g., `{ error: "Internal server error" }`). If error details are needed for debugging, they should be logged on the server side using `console.error`, `console.log`, or an appropriate logger, but should not be sent in the HTTP response. The changes required are: (1) log the complete error object/details on the server, and (2) change the response body in the `catch` block to a generic message. Only the `src/pages/api/debug-env.ts` file needs editing, in the `catch` block (lines 32-37).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
