### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/WishlistForms.tsx
+++ b/src/components/WishlistForms.tsx
@@ -553,6 +553,20 @@ const WishlistForm = ({ services = [], practitioners = [], user: initialUser = n
     }
   };
 
+  // Allow only http and https schemes
+  const sanitizeUrl = (url: string | undefined | null): string => {
+    if (!url) return "#";
+    try {
+      const urlObj = new URL(url);
+      if (urlObj.protocol === "http:" || urlObj.protocol === "https:") {
+        return url;
+      }
+    } catch {
+      // If invalid, fall through below
+    }
+    return "#";
+  };
+
   const handleManualRepoSubmit = () => {
     setError('');
     const repoData = parseProjectUrl(manualRepoUrl);
@@ -1610,7 +1624,7 @@ ${repositories[0].url}
                   {selectedRepo ? selectedRepo.name : manualRepoData?.name}
                 </p>
                 <a 
-                  href={selectedRepo ? selectedRepo.html_url : manualRepoData?.url}
+                  href={selectedRepo ? sanitizeUrl(selectedRepo.html_url) : sanitizeUrl(manualRepoData?.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-blue-600 hover:text-blue-800 underline break-all"


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/22](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/22)

To fix the issue, we must ensure that any user-entered URL placed in the `href` attribute is validated and sanitized so that only safe schemes are allowed (typically only allowing `http://` and `https://`). This means, specifically, blocking URLs with the `javascript:` scheme, as well as `data:` and other potentially dangerous schemes.

The best way is to add a utility function to validate URLs for safe schemes. Before rendering the link, check if the chosen `href` value uses a permitted protocol (`http` or `https`). If not, either withhold rendering the link or render it as plain text, or set its `href` to a safe fallback (such as `#`). 

The fix touches:
- The region where the link's `href` is set (lines ~1613–1618).
- A utility validator function for URL scheme checking, defined within the file (src/components/WishlistForms.tsx).
- Optionally, apply the same check wherever the suspicious URL might be rendered as `href`.

No additional dependencies are needed, as URL scheme checks can be done using built-in JavaScript functionality (`URL`), and the code already imports utilities (e.g., from `../config/app`). 

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
