### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-wishlist-json.yml
+++ b/.github/workflows/update-wishlist-json.yml
@@ -1,4 +1,6 @@
 name: Update Wishlist JSON Feed
+permissions:
+  contents: write
 
 # Trigger when wishlists are approved, rejected, or deleted via API
 # This action can be manually triggered or called from the application


### PR DESCRIPTION
Potential fix for [https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/17](https://github.com/oss-wishlist/oss-wishlist-website/security/code-scanning/17)

**How to, in general terms, fix the problem:**  
To fix the problem, explicitly set the `permissions` key in the workflow. This should be done either at the workflow root (applies to all jobs) or at the relevant job level. The permissions should follow the principle of least privilege: in this case, since the workflow pushes commits, it needs `contents: write`.

**Detailed description of the single best way to fix the problem without changing existing functionality:**  
Add a `permissions:` block at the top level of the workflow, after the `name:` and before `on:`. Set `contents: write`. This meets the requirements for pushing commits, while not unnecessarily granting other permissions.

**What is needed:**  
- In `.github/workflows/update-wishlist-json.yml`, add  
  ```
  permissions:
    contents: write
  ```  
  after the `name:` field and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
