### PR TITLE
feat: add winding-down service, update playbook submodule, reorder ca…

### DIFF
--- a/src/content/services/winding-down.md
+++ b/src/content/services/winding-down.md
@@ -1,0 +1,13 @@
+---
+title: "Winding Down an Open Source Project"
+description: "Structured support for responsibly sunsetting, archiving, or transferring an open source project — minimizing ecosystem disruption while preserving knowledge and enabling continuity."
+type: service
+service_type: consulting
+available: true
+playbook: winding-down
+pricing:
+  small: 3000
+  medium: 5500
+  large: 9000
+impact: "A responsible wind-down protects dependents, preserves institutional knowledge, and reduces long-term ecosystem risk — turning a difficult transition into a thoughtful handoff."
+---

--- a/src/pages/catalog.astro
+++ b/src/pages/catalog.astro
@@ -14,10 +14,20 @@ try {
 } catch {
   // db unavailable — dropdown will just be empty
 }
-// Sort services: general-need first, then alphabetically
+// Sort services: featured first in defined order, then alphabetically
+const featuredOrder = [
+  'digital-sovereignty',
+  'leadership-onboarding',
+  'governance-setup',
+  'moderation-strategy',
+  'winding-down',
+];
 const services = servicesRaw.sort((a, b) => {
-  if (a.slug === 'general-need') return -1;
-  if (b.slug === 'general-need') return 1;
+  const aIdx = featuredOrder.indexOf(a.slug);
+  const bIdx = featuredOrder.indexOf(b.slug);
+  if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
+  if (aIdx !== -1) return -1;
+  if (bIdx !== -1) return 1;
   return a.data.title.localeCompare(b.data.title);
 });
 const playbooks = await getCollection('playbooks-external');


### PR DESCRIPTION
…talog

- Update playbooks-external submodule to ececac5
- Add src/content/services/winding-down.md linked to winding-down playbook
- Reorder catalog: digital-sovereignty, leadership-onboarding, governance-setup, moderation-strategy, winding-down first